### PR TITLE
OS X windowing fixes and a minor speed tweak.

### DIFF
--- a/src/behavior.cpp
+++ b/src/behavior.cpp
@@ -473,8 +473,8 @@ void Behavior::update()
         parent->y_pos += vel_y;
     }
     if(movement == Movement::Diagonal){
-        vel_x = std::sqrt(speed*speed*2) * std::cos(angle);
-        vel_y = -std::sqrt(speed*speed*2) * std::sin(angle);
+        vel_x = speed * std::cos(angle);
+        vel_y = -speed * std::sin(angle);
         parent->x_pos += vel_x;
         parent->y_pos += vel_y;
     }

--- a/src/pony.cpp
+++ b/src/pony.cpp
@@ -60,18 +60,18 @@ Pony::Pony(const QString path, ConfigWindow *config, QWidget *parent) :
     setAttribute(Qt::WA_ShowWithoutActivating);
 
 #if defined QT_MAC_USE_COCOA && QT_VERSION >= 0x040800
-	//removes shadows that lag behind animation on OS X. QT 4.8+ needed.
+    //removes shadows that lag behind animation on OS X. QT 4.8+ needed.
     setAttribute(Qt::WA_MacNoShadow, true);
 #endif
 
 #if defined QT_MAC_USE_COCOA
-	// on OS X, tool windows are hidden when another program gains focus.
+    // on OS X, tool windows are hidden when another program gains focus.
     Qt::WindowFlags windowflags = Qt::FramelessWindowHint;
 #else
     Qt::WindowFlags windowflags = Qt::FramelessWindowHint | Qt::Tool;
 #endif
 
-	always_on_top = config->getSetting<bool>("general/always-on-top");
+    always_on_top = config->getSetting<bool>("general/always-on-top");
     if(always_on_top) {
         windowflags |= Qt::WindowStaysOnTopHint;
     }

--- a/src/pony.cpp
+++ b/src/pony.cpp
@@ -59,8 +59,19 @@ Pony::Pony(const QString path, ConfigWindow *config, QWidget *parent) :
     setAttribute(Qt::WA_TranslucentBackground, true);
     setAttribute(Qt::WA_ShowWithoutActivating);
 
+#if defined QT_MAC_USE_COCOA && QT_VERSION >= 0x040800
+	//removes shadows that lag behind animation on OS X. QT 4.8+ needed.
+    setAttribute(Qt::WA_MacNoShadow, true);
+#endif
+
+#if defined QT_MAC_USE_COCOA
+	// on OS X, tool windows are hidden when another program gains focus.
+    Qt::WindowFlags windowflags = Qt::FramelessWindowHint;
+#else
     Qt::WindowFlags windowflags = Qt::FramelessWindowHint | Qt::Tool;
-    always_on_top = config->getSetting<bool>("general/always-on-top");
+#endif
+
+	always_on_top = config->getSetting<bool>("general/always-on-top");
     if(always_on_top) {
         windowflags |= Qt::WindowStaysOnTopHint;
     }


### PR DESCRIPTION
I recently got a Mac for side work and tried installing qt-ponies on it. It mostly worked except that the ponies had shadows that lagged behind the animation, only updating every half second or so. And ponies would disappear whenenever qt-ponies lost focus.

The shadows could be removed by setting the Qt::WA_MacNoShadow window attribute, but it's only supported on Qt 4.8 and later. The default version provided by MacPorts (qt4-mac) is only 4.7, but the testing package (qt4-mac-devel) is up to date.

The second issue was because windows with the Qt::Tool attribute are hidden by design on Qt for Mac when application focus is lost. Removing the attribute on Mac didn't seem to hurt anything.

I also noticed that speed is increased when moving diagonally. I figured the sqrt(2_speed_speed) was a mistake (basically 1.4*speed) and changed it to just speed.
